### PR TITLE
fix: aggressive state writing

### DIFF
--- a/src/main/listeners/save-export-listener.ts
+++ b/src/main/listeners/save-export-listener.ts
@@ -1,7 +1,7 @@
-import IpcMainEvent = Electron.IpcMainEvent;
 import { dialog } from 'electron';
 import { writeFileSync } from 'fs';
 import path from 'path';
+import IpcMainEvent = Electron.IpcMainEvent;
 
 async function writeFile(filePath: string, dataUrl: any) {
   const [, encodedString] = dataUrl.split(',');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -19,6 +19,8 @@ import { workbenchStateUpdateListener } from './listeners/workbench-state-update
 import { openWorkbenchListener } from './listeners/open-workbench-listener';
 import { loadRecentListener } from './listeners/load-recent-listener';
 import { saveExportListener } from './listeners/save-export-listener';
+import { WorkbenchState } from '../renderer/state';
+import IpcMainEvent = Electron.IpcMainEvent;
 
 export default class AppUpdater {
   constructor() {
@@ -26,6 +28,16 @@ export default class AppUpdater {
     autoUpdater.logger = log;
     autoUpdater.checkForUpdatesAndNotify();
   }
+}
+
+function debounce(func: () => void, timeout = 500) {
+  let timer: any;
+  return (...args: []) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -39,7 +51,12 @@ ipcMain.on('ipc-example', async (event, arg) => {
 // @ts-ignore
 app.on('open-file', loadRecentListener);
 ipcMain.on('open-workbench', openWorkbenchListener);
-ipcMain.on('workbench-state-update', workbenchStateUpdateListener);
+ipcMain.on(
+  'workbench-state-update',
+  debounce((event: IpcMainEvent, state: WorkbenchState) =>
+    workbenchStateUpdateListener(event, state)
+  )
+);
 ipcMain.on('save-export', saveExportListener);
 
 if (process.env.NODE_ENV === 'production') {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,11 +30,12 @@ export default class AppUpdater {
   }
 }
 
-function debounce(func: () => void, timeout = 500) {
+function debounce(func: (..._args: any) => any, timeout = 500) {
   let timer: any;
   return (...args: []) => {
     clearTimeout(timer);
     timer = setTimeout(() => {
+      // @ts-ignore - I don't know how to annotate this type properly, so just ignoring
       func.apply(this, args);
     }, timeout);
   };

--- a/src/renderer/state/zustand-state.ts
+++ b/src/renderer/state/zustand-state.ts
@@ -45,7 +45,7 @@ export const useWorkbenchStore = create<WorkbenchState>(
       ),
       {
         name: 'workbenchState',
-        getStorage: () => sessionStorage,
+        getStorage: () => localStorage,
       }
     )
   )


### PR DESCRIPTION
fixes #19 

In this change I'm putting a debounce method around the updating of state on the file system. This should make things less chatty with the file system and likely improve performance (and battery life).

Additionally, I noticed that it was using sessionStorage to hold state in the browser and that's not very useful through restarts so i switched it to localStorage